### PR TITLE
Improve performance by making the script multi-threaded

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ A simple Python-based integrity checker for files on an exFAT (or any) filesyste
   - Removed files
 - **Configurable Database Location**: Use a default `integrity.db` or specify a custom path.
 - **Cross-Platform**: Works wherever Python 3.6+ and SQLite are available (macOS, Linux, Windows).
+- **Multi-threaded Performance**: Utilizes multi-threading to improve performance by processing files concurrently.
 
 ---
 


### PR DESCRIPTION
Make the script multi-threaded to improve performance.

* **exfat_integrity_checker.py**
  - Import `concurrent.futures` for multi-threading.
  - Add `process_file` function to handle file processing in parallel.
  - Modify `init_db` function to use `ThreadPoolExecutor` for parallel processing of files.
  - Modify `check_db` function to use `ThreadPoolExecutor` for parallel processing of files.

* **readme.md**
  - Update the "Features" section to mention multi-threaded performance.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spicyGrape/exfat_integrity_checker/pull/1?shareId=4198e027-4da4-4d20-8acb-b6b33de94b15).